### PR TITLE
Add AND, OR, NOT logical operators for programmatic querying

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -83,16 +83,14 @@ SuperSave provides a fluent API for building complex queries with AND, OR, and N
 
 To query entities programmatically (not via HTTP API), use the `createQuery()` method on a repository:
 
-```typescript
-const planetRepository = await superSave.addEntity(planetEntity);
-const query = planetRepository.createQuery();
+    const planetRepository = await superSave.addEntity(planetEntity);
+    const query = planetRepository.createQuery();
 
-// Simple equality filter
-query.eq('name', 'Earth');
+    // Simple equality filter
+    query.eq('name', 'Earth');
 
-// Get results
-const planets = await planetRepository.getByQuery(query);
-```
+    // Get results
+    const planets = await planetRepository.getByQuery(query);
 
 ### Available Filter Methods
 
@@ -113,94 +111,78 @@ const planets = await planetRepository.getByQuery(query);
 
 When chaining filter methods without specifying a logical operator, they are automatically combined with AND:
 
-```typescript
-const query = planetRepository.createQuery();
-query.eq('name', 'Earth').eq('distance', 100);
-// Generates: WHERE name = 'Earth' AND distance = 100
-```
+    const query = planetRepository.createQuery();
+    query.eq('name', 'Earth').eq('distance', 100);
+    // Generates: WHERE name = 'Earth' AND distance = 100
 
 ### Explicit AND
 
 Use `and()` to explicitly create an AND group:
 
-```typescript
-const query = planetRepository.createQuery();
-query.and().eq('name', 'Earth').eq('distance', 100);
-// Generates: WHERE (name = 'Earth' AND distance = 100)
-```
+    const query = planetRepository.createQuery();
+    query.and().eq('name', 'Earth').eq('distance', 100);
+    // Generates: WHERE (name = 'Earth' AND distance = 100)
 
 ### OR
 
 Use `or()` to create an OR group:
 
-```typescript
-const query = planetRepository.createQuery();
-query.or().eq('name', 'Earth').eq('name', 'Mars');
-// Generates: WHERE (name = 'Earth' OR name = 'Mars')
-```
+    const query = planetRepository.createQuery();
+    query.or().eq('name', 'Earth').eq('name', 'Mars');
+    // Generates: WHERE (name = 'Earth' OR name = 'Mars')
 
 ### NOT
 
 Use `not()` to negate a filter:
 
-```typescript
-const query = planetRepository.createQuery();
-query.not().eq('name', 'Pluto');
-// Generates: WHERE NOT (name = 'Pluto')
-```
+    const query = planetRepository.createQuery();
+    query.not().eq('name', 'Pluto');
+    // Generates: WHERE NOT (name = 'Pluto')
 
 ### Nested Groups
 
 Pass sub-queries to `or()` or `and()` to create nested conditions:
 
-```typescript
-const query = planetRepository.createQuery();
+    const query = planetRepository.createQuery();
 
-// OR of two AND groups
-query.or(
-  planetRepository.createQuery().and().eq('name', 'Earth').eq('distance', 100),
-  planetRepository.createQuery().and().eq('name', 'Venus').eq('distance', 200)
-);
-// Generates: WHERE ((name = 'Earth' AND distance = 100) OR (name = 'Venus' AND distance = 200))
-```
+    // OR of two AND groups
+    query.or(
+      planetRepository.createQuery().and().eq('name', 'Earth').eq('distance', 100),
+      planetRepository.createQuery().and().eq('name', 'Venus').eq('distance', 200)
+    );
+    // Generates: WHERE ((name = 'Earth' AND distance = 100) OR (name = 'Venus' AND distance = 200))
 
 ### Complex Queries
 
 Combine multiple logical operators for complex conditions:
 
-```typescript
-const query = planetRepository.createQuery();
+    const query = planetRepository.createQuery();
 
-// Find visible planets that are either Earth or Mars
-query.and().eq('visible', true).or(
-  planetRepository.createQuery().eq('name', 'Earth'),
-  planetRepository.createQuery().eq('name', 'Mars')
-);
+    // Find visible planets that are either Earth or Mars
+    query.and().eq('visible', true).or(
+      planetRepository.createQuery().eq('name', 'Earth'),
+      planetRepository.createQuery().eq('name', 'Mars')
+    );
 
-const planets = await planetRepository.getByQuery(query);
-```
+    const planets = await planetRepository.getByQuery(query);
 
 ### Sorting and Limiting
 
-```typescript
-const query = planetRepository.createQuery();
-query
-  .or().eq('name', 'Earth').eq('name', 'Mars')
-  .sort('name', 'desc')  // Sort by name descending
-  .limit(10)             // Maximum 10 results
-  .offset(5);            // Skip first 5 results
+    const query = planetRepository.createQuery();
+    query
+      .or().eq('name', 'Earth').eq('name', 'Mars')
+      .sort('name', 'desc')  // Sort by name descending
+      .limit(10)             // Maximum 10 results
+      .offset(5);            // Skip first 5 results
 
-const planets = await planetRepository.getByQuery(query);
-```
+    const planets = await planetRepository.getByQuery(query);
 
 ### Getting a Single Result
 
-```typescript
-const query = planetRepository.createQuery();
-query.eq('name', 'Earth');
+    const query = planetRepository.createQuery();
+    query.eq('name', 'Earth');
 
-const planet = await planetRepository.getOneByQuery(query);
-```
+    const planet = await planetRepository.getOneByQuery(query);
 
 **Note:** To use filters, the field must be defined in `filterSortFields` when creating the entity or collection.
 

--- a/README.MD
+++ b/README.MD
@@ -72,8 +72,137 @@ You can use `addEntity` to create a database-only entity, use `addCollection` to
 
 ## Close connection
 
-You can use `await superSave.close()` to close the connection with the underlying storage. For _sqlite_ this means that the connection is closed
-and the superSave instance can no longer be used. When using _mysql_ this will close all active connections in the pool.
+You can use `await superSave.close()` to close connection with underlying storage. For _sqlite_ this means that connection is closed
+and superSave instance can no longer be used. When using _mysql_ this will close all active connections in the pool.
+
+## Querying with Logical Operators
+
+SuperSave provides a fluent API for building complex queries with AND, OR, and NOT logical operators.
+
+### Basic Querying
+
+To query entities programmatically (not via HTTP API), use the `createQuery()` method on a repository:
+
+```typescript
+const planetRepository = await superSave.addEntity(planetEntity);
+const query = planetRepository.createQuery();
+
+// Simple equality filter
+query.eq('name', 'Earth');
+
+// Get results
+const planets = await planetRepository.getByQuery(query);
+```
+
+### Available Filter Methods
+
+| Method | Description |
+| ------- | ----------- |
+| `eq(field, value)` | Equals |
+| `gt(field, value)` | Greater than |
+| `gte(field, value)` | Greater than or equal |
+| `lt(field, value)` | Less than |
+| `lte(field, value)` | Less than or equal |
+| `like(field, value)` | Like (use `*` as wildcard) |
+| `in(field, values[])` | In array of values |
+| `sort(field, direction)` | Sort by field (`'asc'` or `'desc'`) |
+| `limit(n)` | Limit results |
+| `offset(n)` | Skip results (pagination) |
+
+### Implicit AND (Default)
+
+When chaining filter methods without specifying a logical operator, they are automatically combined with AND:
+
+```typescript
+const query = planetRepository.createQuery();
+query.eq('name', 'Earth').eq('distance', 100);
+// Generates: WHERE name = 'Earth' AND distance = 100
+```
+
+### Explicit AND
+
+Use `and()` to explicitly create an AND group:
+
+```typescript
+const query = planetRepository.createQuery();
+query.and().eq('name', 'Earth').eq('distance', 100);
+// Generates: WHERE (name = 'Earth' AND distance = 100)
+```
+
+### OR
+
+Use `or()` to create an OR group:
+
+```typescript
+const query = planetRepository.createQuery();
+query.or().eq('name', 'Earth').eq('name', 'Mars');
+// Generates: WHERE (name = 'Earth' OR name = 'Mars')
+```
+
+### NOT
+
+Use `not()` to negate a filter:
+
+```typescript
+const query = planetRepository.createQuery();
+query.not().eq('name', 'Pluto');
+// Generates: WHERE NOT (name = 'Pluto')
+```
+
+### Nested Groups
+
+Pass sub-queries to `or()` or `and()` to create nested conditions:
+
+```typescript
+const query = planetRepository.createQuery();
+
+// OR of two AND groups
+query.or(
+  planetRepository.createQuery().and().eq('name', 'Earth').eq('distance', 100),
+  planetRepository.createQuery().and().eq('name', 'Venus').eq('distance', 200)
+);
+// Generates: WHERE ((name = 'Earth' AND distance = 100) OR (name = 'Venus' AND distance = 200))
+```
+
+### Complex Queries
+
+Combine multiple logical operators for complex conditions:
+
+```typescript
+const query = planetRepository.createQuery();
+
+// Find visible planets that are either Earth or Mars
+query.and().eq('visible', true).or(
+  planetRepository.createQuery().eq('name', 'Earth'),
+  planetRepository.createQuery().eq('name', 'Mars')
+);
+
+const planets = await planetRepository.getByQuery(query);
+```
+
+### Sorting and Limiting
+
+```typescript
+const query = planetRepository.createQuery();
+query
+  .or().eq('name', 'Earth').eq('name', 'Mars')
+  .sort('name', 'desc')  // Sort by name descending
+  .limit(10)             // Maximum 10 results
+  .offset(5);            // Skip first 5 results
+
+const planets = await planetRepository.getByQuery(query);
+```
+
+### Getting a Single Result
+
+```typescript
+const query = planetRepository.createQuery();
+query.eq('name', 'Earth');
+
+const planet = await planetRepository.getOneByQuery(query);
+```
+
+**Note:** To use filters, the field must be defined in `filterSortFields` when creating the entity or collection.
 
 # HTTP API Configuration
 

--- a/src/database/entity-manager/mysql/repository.ts
+++ b/src/database/entity-manager/mysql/repository.ts
@@ -102,6 +102,9 @@ class Repository<T extends BaseEntity> extends BaseRepository<T> {
 
     const filter = condition as QueryFilter;
     if (filter.operator === QueryOperatorEnum.IN) {
+      if (Array.isArray(filter.value) && filter.value.length === 0) {
+        return '1 = 0';
+      }
       const placeholders = filter.value.map(() => '?').join(',');
       values.push(...filter.value);
       return `${this.pool.escapeId(filter.field)} IN(${placeholders})`;

--- a/src/database/entity-manager/query.ts
+++ b/src/database/entity-manager/query.ts
@@ -87,11 +87,27 @@ class Query {
   public and(...queries: Query[]): Query {
     this.finalizeGroup();
     if (queries.length > 0) {
-      const conditions = queries.flatMap((q) => q.getWhere());
-      this.where.push({
-        logicalOperator: LogicalOperatorEnum.AND,
-        conditions,
+      const conditions: QueryCondition[] = [];
+      queries.forEach((q) => {
+        const subqueryWhere = q.getWhere();
+        if (subqueryWhere.length === 0) {
+          return;
+        }
+        if (subqueryWhere.length === 1) {
+          conditions.push(subqueryWhere[0]);
+        } else {
+          conditions.push({
+            logicalOperator: LogicalOperatorEnum.AND,
+            conditions: subqueryWhere,
+          });
+        }
       });
+      if (conditions.length > 0) {
+        this.where.push({
+          logicalOperator: LogicalOperatorEnum.AND,
+          conditions,
+        });
+      }
     } else {
       this.currentGroup = {
         logicalOperator: LogicalOperatorEnum.AND,
@@ -104,11 +120,27 @@ class Query {
   public or(...queries: Query[]): Query {
     this.finalizeGroup();
     if (queries.length > 0) {
-      const conditions = queries.flatMap((q) => q.getWhere());
-      this.where.push({
-        logicalOperator: LogicalOperatorEnum.OR,
-        conditions,
+      const conditions: QueryCondition[] = [];
+      queries.forEach((q) => {
+        const subqueryWhere = q.getWhere();
+        if (subqueryWhere.length === 0) {
+          return;
+        }
+        if (subqueryWhere.length === 1) {
+          conditions.push(subqueryWhere[0]);
+        } else {
+          conditions.push({
+            logicalOperator: LogicalOperatorEnum.AND,
+            conditions: subqueryWhere,
+          });
+        }
       });
+      if (conditions.length > 0) {
+        this.where.push({
+          logicalOperator: LogicalOperatorEnum.OR,
+          conditions,
+        });
+      }
     } else {
       this.currentGroup = {
         logicalOperator: LogicalOperatorEnum.OR,

--- a/src/database/entity-manager/sqlite/repository.ts
+++ b/src/database/entity-manager/sqlite/repository.ts
@@ -8,10 +8,12 @@ const { generate } = shortUuid;
 import type {
   BaseEntity,
   EntityDefinition,
+  LogicalGroup,
+  QueryCondition,
   QueryFilter,
   QuerySort,
 } from '../../types.js';
-import { QueryOperatorEnum } from '../../types.js';
+import { LogicalOperatorEnum, QueryOperatorEnum } from '../../types.js';
 import type Query from '../query.js';
 import BaseRepository from '../repository.js';
 
@@ -58,41 +60,76 @@ class Repository<T extends BaseEntity> extends BaseRepository<T> {
     return [];
   }
 
+  private buildWhereClause(
+    condition: QueryCondition,
+    values: (string | number)[]
+  ): string {
+    if ('logicalOperator' in condition) {
+      const group = condition as LogicalGroup;
+      const clauses = group.conditions
+        .map((c) => this.buildWhereClause(c, values))
+        .filter(Boolean);
+
+      if (clauses.length === 0) return '';
+      if (clauses.length === 1) {
+        return group.logicalOperator === LogicalOperatorEnum.NOT
+          ? `NOT (${clauses[0]})`
+          : `(${clauses[0]})`;
+      }
+
+      const joined = clauses.join(` ${group.logicalOperator} `);
+      return group.logicalOperator === LogicalOperatorEnum.NOT
+        ? `NOT (${joined})`
+        : `(${joined})`;
+    }
+
+    const filter = condition as QueryFilter;
+    if (filter.operator === QueryOperatorEnum.IN) {
+      const placeholders = filter.value.map(() => '?').join(',');
+      values.push(...filter.value);
+      return `"${filter.field}" IN (${placeholders})`;
+    }
+
+    if (
+      filter.operator === QueryOperatorEnum.EQUALS &&
+      (filter.value === null || filter.value === undefined)
+    ) {
+      return `"${filter.field}" IS NULL`;
+    }
+
+    values.push(this.getValueForFilter(filter));
+    return `"${filter.field}" ${filter.operator} ?`;
+  }
+
+  private getValueForFilter(filter: QueryFilter): string | number {
+    if (
+      this.definition.filterSortFields &&
+      this.definition.filterSortFields[filter.field] === 'boolean'
+    ) {
+      return ['1', 1, 'true', true].includes(filter.value) ? 1 : 0;
+    }
+
+    if (filter.operator === QueryOperatorEnum.LIKE) {
+      return `${filter.value}`.replace(/\*/g, '%');
+    }
+
+    return filter.value;
+  }
+
   public async getByQuery(query: Query): Promise<T[]> {
     const values: (string | number)[] = [];
-    const where: string[] = [];
 
-    query.getWhere().forEach((queryFilter: QueryFilter) => {
-      if (queryFilter.operator === QueryOperatorEnum.IN) {
-        const placeholders = queryFilter.value.map(() => '?').join(',');
-        where.push(`"${queryFilter.field}" IN (${placeholders})`);
-        values.push(...queryFilter.value);
-      } else if (
-        queryFilter.operator === QueryOperatorEnum.EQUALS &&
-        (queryFilter.value === null || queryFilter.value === undefined)
-      ) {
-        // Handle null comparison - use IS NULL instead of = NULL
-        where.push(`"${queryFilter.field}" IS NULL`);
-      } else {
-        where.push(`"${queryFilter.field}" ${queryFilter.operator} ?`);
-        if (
-          this.definition.filterSortFields &&
-          this.definition.filterSortFields[queryFilter.field] === 'boolean'
-        ) {
-          values.push(
-            ['1', 1, 'true', true].includes(queryFilter.value) ? 1 : 0
-          );
-        } else if (queryFilter.operator === QueryOperatorEnum.LIKE) {
-          values.push(`${queryFilter.value}`.replace(/\*/g, '%'));
-        } else {
-          values.push(queryFilter.value);
-        }
-      }
-    });
+    const conditions = query.getWhere();
+    const whereClauses = conditions
+      .map((condition) => this.buildWhereClause(condition, values))
+      .filter(Boolean);
 
-    let sqlQuery = `SELECT id,contents FROM ${this.tableName}
-      ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
-    `;
+    let sqlQuery = `SELECT id,contents FROM ${this.tableName}`;
+
+    if (whereClauses.length > 0) {
+      sqlQuery += ` WHERE ${whereClauses.join(' AND ')}`;
+    }
+
     if (query.getSort().length > 0) {
       sqlQuery = `${sqlQuery} ORDER BY ${query
         .getSort()

--- a/src/database/entity-manager/sqlite/repository.ts
+++ b/src/database/entity-manager/sqlite/repository.ts
@@ -85,6 +85,9 @@ class Repository<T extends BaseEntity> extends BaseRepository<T> {
 
     const filter = condition as QueryFilter;
     if (filter.operator === QueryOperatorEnum.IN) {
+      if (Array.isArray(filter.value) && filter.value.length === 0) {
+        return '1 = 0';
+      }
       const placeholders = filter.value.map(() => '?').join(',');
       values.push(...filter.value);
       return `"${filter.field}" IN (${placeholders})`;

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -37,6 +37,19 @@ export enum QueryOperatorEnum {
   LIKE = 'LIKE',
 }
 
+export enum LogicalOperatorEnum {
+  AND = 'AND',
+  OR = 'OR',
+  NOT = 'NOT',
+}
+
+export interface LogicalGroup {
+  logicalOperator: LogicalOperatorEnum;
+  conditions: QueryCondition[];
+}
+
+export type QueryCondition = QueryFilter | LogicalGroup;
+
 export type QueryFilter = {
   operator: QueryOperatorEnum;
   field: string;

--- a/tests/unit/logical-operators.test.ts
+++ b/tests/unit/logical-operators.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { EntityDefinition } from '../../dist/index.js';
+import { SuperSave } from '../../dist/index.js';
+import getConnection from '../connection.js';
+import { planetEntity } from '../entities.js';
+import { clear } from '../mysql.js';
+import type { Planet } from '../types.js';
+
+beforeEach(clear);
+
+describe('logical operators: AND, OR, NOT', () => {
+  test('explicit AND with fluent chaining', async () => {
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+        distance: 'number',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository =
+      await superSave.addEntity<Planet>(filteredPlanetEntity);
+
+    await planetRepository.create({ name: 'Earth', distance: 100 });
+    await planetRepository.create({ name: 'Earth', distance: 200 });
+    await planetRepository.create({ name: 'Mars', distance: 100 });
+
+    const query = planetRepository.createQuery();
+    query.and().eq('name', 'Earth').eq('distance', 100);
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(1);
+    expect((results[0] as Planet).name).toBe('Earth');
+    expect((results[0] as Planet).distance).toBe(100);
+
+    await superSave.close();
+  });
+
+  test('OR with fluent chaining', async () => {
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository =
+      await superSave.addEntity<Planet>(filteredPlanetEntity);
+
+    await planetRepository.create({ name: 'Earth' });
+    await planetRepository.create({ name: 'Mars' });
+    await planetRepository.create({ name: 'Venus' });
+
+    const query = planetRepository.createQuery();
+    query.or().eq('name', 'Earth').eq('name', 'Mars');
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(2);
+    expect(results.map((p) => (p as Planet).name).sort()).toEqual([
+      'Earth',
+      'Mars',
+    ]);
+
+    await superSave.close();
+  });
+
+  test('NOT single filter', async () => {
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository =
+      await superSave.addEntity<Planet>(filteredPlanetEntity);
+
+    await planetRepository.create({ name: 'Earth' });
+    await planetRepository.create({ name: 'Mars' });
+    await planetRepository.create({ name: 'Pluto' });
+
+    const query = planetRepository.createQuery();
+    query.not().eq('name', 'Pluto');
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(2);
+    expect(results.map((p) => (p as Planet).name).sort()).toEqual([
+      'Earth',
+      'Mars',
+    ]);
+
+    await superSave.close();
+  });
+
+  test('nested groups: OR of two ANDs', async () => {
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+        distance: 'number',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository =
+      await superSave.addEntity<Planet>(filteredPlanetEntity);
+
+    await planetRepository.create({ name: 'Earth', distance: 100 });
+    await planetRepository.create({ name: 'Mars', distance: 200 });
+    await planetRepository.create({ name: 'Jupiter', distance: 100 });
+    await planetRepository.create({ name: 'Venus', distance: 200 });
+
+    const query = planetRepository.createQuery();
+    query.or(
+      planetRepository
+        .createQuery()
+        .and()
+        .eq('name', 'Earth')
+        .eq('distance', 100),
+      planetRepository
+        .createQuery()
+        .and()
+        .eq('name', 'Venus')
+        .eq('distance', 200)
+    );
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(2);
+    expect(results.map((p) => (p as Planet).name).sort()).toEqual([
+      'Earth',
+      'Venus',
+    ]);
+
+    await superSave.close();
+  });
+
+  test('complex: AND with OR sub-group', async () => {
+    interface PlanetWithVisible extends Planet {
+      visible: boolean;
+    }
+
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+        visible: 'boolean',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository =
+      await superSave.addEntity<PlanetWithVisible>(filteredPlanetEntity);
+
+    await planetRepository.create({ name: 'Earth', visible: true });
+    await planetRepository.create({ name: 'Mars', visible: true });
+    await planetRepository.create({ name: 'Jupiter', visible: false });
+    await planetRepository.create({ name: 'Venus', visible: false });
+
+    const query = planetRepository.createQuery();
+    query
+      .and()
+      .eq('visible', true)
+      .or(
+        planetRepository.createQuery().eq('name', 'Mars'),
+        planetRepository.createQuery().eq('name', 'Venus')
+      );
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(1);
+    expect((results[0] as PlanetWithVisible).name).toBe('Mars');
+
+    await superSave.close();
+  });
+
+  test('backward compatibility: implicit AND still works', async () => {
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+        distance: 'number',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository =
+      await superSave.addEntity<Planet>(filteredPlanetEntity);
+
+    await planetRepository.create({ name: 'Earth', distance: 100 });
+    await planetRepository.create({ name: 'Earth', distance: 200 });
+    await planetRepository.create({ name: 'Mars', distance: 100 });
+
+    const query = planetRepository.createQuery();
+    query.eq('name', 'Earth').eq('distance', 100);
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(1);
+    expect((results[0] as Planet).name).toBe('Earth');
+
+    await superSave.close();
+  });
+
+  test('mixed: implicit AND with explicit OR', async () => {
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+        distance: 'number',
+        visible: 'boolean',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository = await superSave.addEntity<
+      Planet & { visible: boolean }
+    >(filteredPlanetEntity);
+
+    await planetRepository.create({
+      name: 'Earth',
+      distance: 100,
+      visible: true,
+    });
+    await planetRepository.create({
+      name: 'Mars',
+      distance: 200,
+      visible: true,
+    });
+    await planetRepository.create({
+      name: 'Jupiter',
+      distance: 100,
+      visible: false,
+    });
+
+    const query = planetRepository.createQuery();
+    query
+      .eq('visible', true)
+      .or(
+        planetRepository.createQuery().eq('distance', 100),
+        planetRepository.createQuery().eq('distance', 200)
+      );
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(2);
+
+    await superSave.close();
+  });
+});

--- a/tests/unit/logical-operators.test.ts
+++ b/tests/unit/logical-operators.test.ts
@@ -246,4 +246,28 @@ describe('logical operators: AND, OR, NOT', () => {
 
     await superSave.close();
   });
+
+  test('IN with empty array returns no results', async () => {
+    const filteredPlanetEntity: EntityDefinition = {
+      ...planetEntity,
+      filterSortFields: {
+        name: 'string',
+      },
+    };
+
+    const superSave: SuperSave = await SuperSave.create(getConnection());
+    const planetRepository =
+      await superSave.addEntity<Planet>(filteredPlanetEntity);
+
+    await planetRepository.create({ name: 'Earth' });
+    await planetRepository.create({ name: 'Mars' });
+
+    const query = planetRepository.createQuery();
+    query.in('name', []);
+
+    const results = await planetRepository.getByQuery(query);
+    expect(results).toHaveLength(0);
+
+    await superSave.close();
+  });
 });


### PR DESCRIPTION
- Add LogicalOperatorEnum, LogicalGroup, and QueryCondition types
- Implement and(), or(), not() fluent methods in Query class
- Add recursive buildWhereClause() methods to MySQL and SQLite repositories
- Maintain backward compatibility with implicit AND
- Add comprehensive test coverage with 7 test cases
- Update README with querying documentation and examples
- Support nested query groups for complex conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fluent query combinators supporting AND, OR, and NOT, plus nested grouping for complex filters.

* **Documentation**
  * New "Querying with Logical Operators" section with extensive examples, usage patterns, and clarified connection-close messaging for storage/sqlite.

* **Tests**
  * Added unit tests validating AND/OR/NOT behavior, nested groups, mixed implicit/explicit logic, and backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->